### PR TITLE
Switch npm syntax to yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Next, change into the new directory and install the following dependencies:
 ```sh
 cd lens-app
 
-npm install ethers graphql urql
+yarn add ethers graphql urql
 ```
 
 Now we need to configure Next.js to allow IPFS and other file sources. To do so, open `next.config.js` and replace what's there with the following code:
@@ -288,7 +288,7 @@ We then update the local state to save the profiles.
 To run the app, run the following command:
 
 ```sh
-npm run dev
+yarn dev
 ```
 
 ## Profile View


### PR DESCRIPTION
On line 18 and 291, the commands used npm package manager for installaing dependencies and running the dev environment. However,  `npx create-next-app` uses yarn by default. Additionally, in the following [workshop video](https://www.youtube.com/watch?v=ESu4uSYEi50) as well, you seem to use the yarn command to install dependencies. It is not a major blocker but just submitting a quick PR for it in case you want to make the suggested changes. Thanks!